### PR TITLE
changed to test-path as it would fail if the file didnt exist

### DIFF
--- a/update_xi.ps1
+++ b/update_xi.ps1
@@ -12,7 +12,7 @@ $file_txt = @'
 '@
 
 
-if (Get-Item "${game_path}file.txt") {
+if (Test-Path "${game_path}file.txt") {
     Remove-Item "${game_path}file.txt"
 }
 


### PR DESCRIPTION
fixes error currently showing on first run since file.txt doesnt exist yet

```
PS C:\Users\Kain\Downloads> .\update_xi.ps1
Get-Item : Cannot find path 'C:\Program Files (x86)\PlayOnline\SquareEnix\FINAL FANTASY XI\file.txt' because it does
not exist.
At C:\Users\Kain\Downloads\update_xi.ps1:15 char:5
+ if (Get-Item "${game_path}file.txt") {
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Program File...ASY XI\file.txt:String) [Get-Item], ItemNotFoundExcep
   tion
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand
```